### PR TITLE
ISSN and eISSN should only apply to a Collection, not a Document

### DIFF
--- a/bibo.n3.owl
+++ b/bibo.n3.owl
@@ -1133,11 +1133,7 @@ terms:issued rdf:type owl:DatatypeProperty ;
        
        rdfs:range rdfs:Literal ;
        
-       rdfs:domain [ rdf:type owl:Class ;
-                     owl:unionOf ( :Collection
-                                   :Document
-                                 )
-                   ] .
+       rdfs:domain :Collection .
 
 
 
@@ -1235,11 +1231,7 @@ terms:issued rdf:type owl:DatatypeProperty ;
       
       rdfs:range rdfs:Literal ;
       
-      rdfs:domain [ rdf:type owl:Class ;
-                    owl:unionOf ( :Collection
-                                  :Document
-                                )
-                  ] .
+      rdfs:domain :Collection .
 
 
 

--- a/bibo.xml.owl
+++ b/bibo.xml.owl
@@ -1093,14 +1093,7 @@ We suggest to use this property instead of the deprecated &quot;bibo:content&quo
     <owl:DatatypeProperty rdf:about="eissn">
         <rdfs:subPropertyOf rdf:resource="identifier"/>
         <rdfs:range rdf:resource="&rdfs;Literal"/>
-        <rdfs:domain>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="Collection"/>
-                    <rdf:Description rdf:about="Document"/>
-                </owl:unionOf>
-            </owl:Class>
-        </rdfs:domain>
+        <rdfs:domain rdf:resource="Collection"/>
     </owl:DatatypeProperty>
     
 
@@ -1202,14 +1195,7 @@ We suggest to use this property instead of the deprecated &quot;bibo:content&quo
     <owl:DatatypeProperty rdf:about="issn">
         <rdfs:subPropertyOf rdf:resource="identifier"/>
         <rdfs:range rdf:resource="&rdfs;Literal"/>
-        <rdfs:domain>
-            <owl:Class>
-                <owl:unionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="Collection"/>
-                    <rdf:Description rdf:about="Document"/>
-                </owl:unionOf>
-            </owl:Class>
-        </rdfs:domain>
+        <rdfs:domain rdf:resource="Collection"/>
     </owl:DatatypeProperty>
     
 


### PR DESCRIPTION
This seems logical, but I might be missing some edge cases where ISSNs are applicable to a single document.