### PR TITLE
More appropriate label for MultiVolumeBook

### DIFF
--- a/bibo.n3.owl
+++ b/bibo.n3.owl
@@ -2304,7 +2304,7 @@ Even if this link is not done in neither the FOAF nor the DCTERMS ontologies thi
 
 :MultiVolumeBook rdf:type owl:Class ;
                  
-                 rdfs:label "Series"@en ;
+                 rdfs:label "Multivolume Book"@en ;
                  
                  rdfs:subClassOf :Collection ,
                                  [ rdf:type owl:Restriction ;

--- a/bibo.xml.owl
+++ b/bibo.xml.owl
@@ -2199,7 +2199,7 @@ Even if this link is not done in neither the FOAF nor the DCTERMS ontologies thi
     <!-- http://purl.org/ontology/bibo/MultiVolumeBook -->
 
     <owl:Class rdf:about="MultiVolumeBook">
-        <rdfs:label xml:lang="en">Series</rdfs:label>
+        <rdfs:label xml:lang="en">Multivolume Book</rdfs:label>
         <rdfs:subClassOf rdf:resource="Collection"/>
         <rdfs:subClassOf>
             <owl:Restriction>


### PR DESCRIPTION
The label for MultiVolumeBook is currently "Series", which appears to be a copy and paste error.  I'm not sure that "Multivolume Book" is the *best* label, but it's more accurate than the status quo.