### PR TITLE
Adding new forms of legal documents

### DIFF
--- a/bibo.owl
+++ b/bibo.owl
@@ -1670,7 +1670,6 @@ Even if this link is not done in neither the FOAF nor the DCTERMS ontologies thi
     </owl:Class>
     
 
-
     <!-- http://purl.org/ontology/bibo/CollectedDocument -->
 
     <owl:Class rdf:about="&bibo;CollectedDocument">
@@ -1729,7 +1728,15 @@ Even if this link is not done in neither the FOAF nor the DCTERMS ontologies thi
         <rdfs:comment xml:lang="en">A meeting for consultation or discussion.</rdfs:comment>
     </owl:Class>
     
+    <!-- http://purl.org/ontology/bibo/Contract -->
 
+    <owl:Class rdf:about="&bibo;Contract">
+        <rdfs:label xml:lang="en">Contract</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&bibo;Agreement"/>
+        <rdfs:isDefinedBy rdf:datatype="&xsd;anyURI">http://purl.org/ontology/bibo/</rdfs:isDefinedBy>
+        <rdfs:comment xml:lang="en">A legal contract.</rdfs:comment>
+        <ns:term_status>unstable</ns:term_status>
+    </owl:Class>
 
     <!-- http://purl.org/ontology/bibo/CourtReporter -->
 

--- a/bibo.owl
+++ b/bibo.owl
@@ -2120,7 +2120,7 @@ Even if this link is not done in neither the FOAF nor the DCTERMS ontologies thi
 
     <owl:Class rdf:about="&bibo;Patent">
         <rdfs:label xml:lang="en">Patent</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&bibo;Document"/>
+        <rdfs:subClassOf rdf:resource="&bibo;LegalDocument"/>
         <rdfs:isDefinedBy rdf:datatype="&xsd;anyURI">http://purl.org/ontology/bibo/</rdfs:isDefinedBy>
         <rdfs:comment xml:lang="en">A document describing the exclusive right granted by a government to an inventor to manufacture, use, or sell an invention for a certain number of years.</rdfs:comment>
         <ns:term_status>stable</ns:term_status>

--- a/bibo.owl
+++ b/bibo.owl
@@ -1541,7 +1541,15 @@ Even if this link is not done in neither the FOAF nor the DCTERMS ontologies thi
         <rdfs:comment xml:lang="en">A scholarly academic article, typically published in a journal.</rdfs:comment>
     </owl:Class>
     
+    <!-- http://purl.org/ontology/bibo/Agreement -->
 
+    <owl:Class rdf:about="&bibo;Agreement">
+        <rdfs:label xml:lang="en">Agreement</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&bibo;LegalDocument"/>
+        <rdfs:isDefinedBy rdf:datatype="&xsd;anyURI">http://purl.org/ontology/bibo/</rdfs:isDefinedBy>
+        <rdfs:comment xml:lang="en">A generic written agreement.</rdfs:comment>
+        <ns:term_status>unstable</ns:term_status>
+    </owl:Class>
 
     <!-- http://purl.org/ontology/bibo/Article -->
 

--- a/bibo.owl
+++ b/bibo.owl
@@ -2336,7 +2336,15 @@ Even if this link is not done in neither the FOAF nor the DCTERMS ontologies thi
         <rdfs:comment xml:lang="en">The academic degree of a Thesis</rdfs:comment>
     </owl:Class>
     
+    <!-- http://purl.org/ontology/bibo/Treaty -->
 
+    <owl:Class rdf:about="&bibo;Treaty">
+        <rdfs:label xml:lang="en">Treaty</rdfs:label>
+        <rdfs:subClassOf rdf:resource="&bibo;Agreement"/>
+        <rdfs:isDefinedBy rdf:datatype="&xsd;anyURI">http://purl.org/ontology/bibo/</rdfs:isDefinedBy>
+        <rdfs:comment xml:lang="en">A multilateral treaty.</rdfs:comment>
+        <ns:term_status>unstable</ns:term_status>
+    </owl:Class>
 
     <!-- http://purl.org/ontology/bibo/Webpage -->
 


### PR DESCRIPTION
Greetings again,

I ran into this issue when trying to catalogue a contract, so it occurred to me that a `bibo:Contract` class would be useful to demarcate it from the more generic `bibo:LegalDocument`. However, a contract is only one particular kind of agreement, so I included a `bibo:Agreement` class, and added a `bibo:Treaty` class as a contrasting example of an agreement which is not strictly a contract.

Finally, I suggest moving `bibo:Patent` to be a subclass of `bibo:LegalDocument`, as patents are in fact legal documents.

I have deliberately separated these moves into different commits on the same branch.